### PR TITLE
Pin GHAs

### DIFF
--- a/github-actions/cysharp-endorlabs-dotnet-example.yml
+++ b/github-actions/cysharp-endorlabs-dotnet-example.yml
@@ -14,14 +14,14 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
       - name: Create lockfile
         run: dotnet restore --use-lock-file ./src
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -31,7 +31,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"

--- a/github-actions/homepage-endorlabs-javascript-example.yml
+++ b/github-actions/homepage-endorlabs-javascript-example.yml
@@ -14,16 +14,16 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
          node-version: 18
       - name: NPM CI
         run: npm ci
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "yolo" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -33,7 +33,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "yolo" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"

--- a/github-actions/langchain-endorlabs-java-maven-example.yml
+++ b/github-actions/langchain-endorlabs-java-maven-example.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Compile Package
         run: mvn clean install
       - name: Scan with Endor Labs
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace  

--- a/github-actions/linked-endorlabs-yarn-example.yml
+++ b/github-actions/linked-endorlabs-yarn-example.yml
@@ -14,16 +14,16 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node
-        uses: mskelton/setup-yarn@v1
+        uses: mskelton/setup-yarn@3c5d9b1e9b3fef69d05b4968efb613594da89f87 # v1.6.0
         with:
          node-version: '16.x'
       - name: Yarn Install
         run: yarn install --frozen-lockfile
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -33,7 +33,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"

--- a/github-actions/metagpt-endorlabs-python-example.yml
+++ b/github-actions/metagpt-endorlabs-python-example.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -29,7 +29,7 @@ jobs:
 
     - name: Endor Labs Watch
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-      uses: endorlabs/github-action@main
+      uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
       with:
         namespace: "example" # Update with your Endor Labs namespace
         scan_summary_output_type: "table"
@@ -39,7 +39,7 @@ jobs:
         additional_args: "--enable=git,analytics,secrets"
     - name: Endor Labs Scan PR to Default Branch
       if: github.event_name == 'pull_request'
-      uses: endorlabs/github-action@main
+      uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
       with:
         namespace: "example" # Update with your Endor Labs namespace
         scan_summary_output_type: "table"

--- a/github-actions/mudblazor-dotnet-endorlabs-example.yml
+++ b/github-actions/mudblazor-dotnet-endorlabs-example.yml
@@ -14,14 +14,14 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup DotNet
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
       - name: Create lockfile
         run: dotnet restore --use-lock-file ./src
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -31,7 +31,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"

--- a/github-actions/packer-plugin-amazon-endorlabs-scan-golang.yml
+++ b/github-actions/packer-plugin-amazon-endorlabs-scan-golang.yml
@@ -14,14 +14,14 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3.6.1
       - name: Build 
         run: go build
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -31,7 +31,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"

--- a/github-actions/sidekiq-endorlabs-ruby-example.yml
+++ b/github-actions/sidekiq-endorlabs-ruby-example.yml
@@ -14,7 +14,7 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Ruby
         uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
         with:
@@ -23,7 +23,7 @@ jobs:
         run: bundle install
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -33,7 +33,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"

--- a/github-actions/twig-endorlabs-php-example.yml
+++ b/github-actions/twig-endorlabs-php-example.yml
@@ -14,9 +14,9 @@ jobs:
       # actions: read # Only needed to upload findings to GitHub
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Set-up PHP"
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: 8.2
           coverage: none
@@ -28,7 +28,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -39,7 +39,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
       - name: Endor Labs Watch
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"
@@ -49,7 +49,7 @@ jobs:
           additional_args: "--enable=git,analytics,secrets"
       - name: Endor Labs Scan PR to Default Branch
         if: github.event_name == 'pull_request'
-        uses: endorlabs/github-action@main
+        uses: endorlabs/github-action@02231267f2d7d3be21f10662fdd39fba143d4bda # v1.1.9
         with:
           namespace: "example" # Update with your Endor Labs namespace
           scan_summary_output_type: "table"


### PR DESCRIPTION
## Summary
                                                                                                                                                                                   
  Pin all GitHub Actions to full commit SHAs to prevent supply chain attacks from compromised tags.                                                                                
                                                                                                                                                                                   
  ## Changes                                                                                                                                                                       
                                                            
  | Action | Old Ref | New Ref | SHA |                                                                                                                                             
  |--------|---------|---------|-----|
  | actions/checkout | v2, v3, v4 | v4.3.1 | [34e1148](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5) |                                      
  | actions/setup-dotnet | v3 | v3.4.2 | [55ec944](https://github.com/actions/setup-dotnet/commit/55ec9447dda3d1cf6bd587150f3262f30ee10815) |                                      
  | actions/setup-node | v3 | v3.9.1 | [3235b87](https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610) |                                          
  | actions/setup-java | v3 | v3.14.1 | [17f84c3](https://github.com/actions/setup-java/commit/17f84c3641ba7b8f6deff6309fc4c864478f5d62) |                                         
  | mskelton/setup-yarn | v1 | v1.6.0 | [3c5d9b1](https://github.com/mskelton/setup-yarn/commit/3c5d9b1e9b3fef69d05b4968efb613594da89f87) |                                        
  | actions/setup-python | v2 | v2.3.4 | [e9aba2c](https://github.com/actions/setup-python/commit/e9aba2c848f5ebd159c070c61ea2c4e2b122355e) |                                      
  | actions/setup-go | v3 | v3.6.1 | [be3c94b](https://github.com/actions/setup-go/commit/be3c94b385c4f180051c996d336f57a34c397495) |                                              
  | actions/cache | v3 | v3.5.0 | [6f8efc2](https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c) |                                                    
  | shivammathur/setup-php | v2 | 2.36.0 | [44454db](https://github.com/shivammathur/setup-php/commit/44454db4f0199b8b9685a5d763dc37cbf79108e1) |                                  
  | endorlabs/github-action | main | v1.1.9 | [0223126](https://github.com/endorlabs/github-action/commit/02231267f2d7d3be21f10662fdd39fba143d4bda) |                              
                                                                                                                                                                                   
  All pinned commits are at least 90 days old. Original version tags are preserved as inline comments for maintainability. `actions/checkout` was consolidated from v2/v3/v4 to    
  v4.3.1 across all files. `shivammathur/setup-php@v2` (2.37.0) was too recent (19 days); pinned to 2.36.0 instead (128 days old). `endorlabs/github-action@main` HEAD was too     
  recent (9 days); pinned to v1.1.9 instead (130 days old).                                                                                                                        
                                                            
  **Files modified:**
  - `github-actions/cysharp-endorlabs-dotnet-example.yml` — pinned checkout, setup-dotnet, endorlabs/github-action
  - `github-actions/homepage-endorlabs-javascript-example.yml` — pinned checkout, setup-node, endorlabs/github-action                                                              
  - `github-actions/langchain-endorlabs-java-maven-example.yml` — pinned checkout, setup-java, endorlabs/github-action                                                             
  - `github-actions/linked-endorlabs-yarn-example.yml` — pinned checkout, setup-yarn, endorlabs/github-action                                                                      
  - `github-actions/metagpt-endorlabs-python-example.yml` — pinned checkout (v2→v4), setup-python, endorlabs/github-action                                                         
  - `github-actions/mudblazor-dotnet-endorlabs-example.yml` — pinned checkout, setup-dotnet, endorlabs/github-action                                                               
  - `github-actions/packer-plugin-amazon-endorlabs-scan-golang.yml` — pinned checkout, setup-go, endorlabs/github-action
  - `github-actions/sidekiq-endorlabs-ruby-example.yml` — pinned checkout, endorlabs/github-action (ruby/setup-ruby was already pinned)                                            
  - `github-actions/twig-endorlabs-php-example.yml` — pinned checkout (v4), setup-php, cache, endorlabs/github-action   